### PR TITLE
ci: add CodeQL static analysis + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  # 1) Python dependencies declared in pyproject.toml (runtime deps + extras).
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # One grouped PR for all Python bumps, instead of one PR per package — far
+      # less noise, and related updates get tested together.
+      python-dependencies:
+        patterns: ["*"]
+    open-pull-requests-limit: 5
+
+  # 2) The GitHub Actions we pinned by commit SHA. Dependabot bumps the SHA *and*
+  # the `# vN` comment for us, so SHA-pinning stays current without manual toil —
+  # this is what makes "pin by SHA" sustainable rather than a maintenance burden.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,4 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+    open-pull-requests-limit: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,10 @@ on:
 permissions: {}
 
 concurrency:
-  group: codeql-${{ github.ref }}
+  # Key by event_name too: a push to main and the weekly schedule both resolve
+  # github.ref to refs/heads/main, so without this they'd share a slot and
+  # cancel-in-progress would let one silently kill the other (Claude review).
+  group: codeql-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -31,7 +34,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: python
           # Broader than the default query pack (adds more security queries);
@@ -39,4 +42,4 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+# Static-analysis security scanning. Builds a queryable database of the code and
+# runs security queries against it (no code execution). Runs on PRs and pushes to
+# main, PLUS weekly — the schedule re-scans unchanged code so newly-published query
+# patterns (i.e. vulnerability classes discovered later) still get applied.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "27 6 * * 1" # Mondays ~06:27 UTC (off the top-of-hour scheduler stampede)
+
+# Least privilege at the top; the job grants only what CodeQL needs.
+permissions: {}
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # read the source
+      security-events: write # upload findings to the repo's Security tab
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          languages: python
+          # Broader than the default query pack (adds more security queries);
+          # "security-and-quality" exists too but is noisier with style/maintainability.
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3


### PR DESCRIPTION
## What
The deterministic supply-chain/security layer beneath the human + AI review.
- `.github/workflows/codeql.yml` — CodeQL static analysis (Python)
- `.github/dependabot.yml` — weekly grouped dependency + GitHub Actions updates

## Why
- **CodeQL** catches known-dangerous patterns (injection, path traversal) on every PR plus a weekly schedule — the schedule re-scans *unchanged* code so vulnerability classes discovered later still get applied. `security-extended` query pack; least-privilege permissions (`contents: read` + `security-events: write` only); actions SHA-pinned; concurrency-controlled.
- **Dependabot** keeps `pyproject.toml` deps and the SHA-pinned actions current with grouped PRs (limits noise). It's what makes SHA-pinning sustainable — it bumps each `@sha # vN` automatically.

Heads-up: CodeQL's first scan may flag the `subprocess` argument-injection surface already noted in review — expected, and a useful second signal; we'll triage in the Security tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
