### PR TITLE
ci: install nanoq from bioconda, drop the flaky cargo build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,22 +152,15 @@ jobs:
               - bioconda
             channel_priority: strict
           create-args: >-
-            python=3.11 chopper cramino mosdepth=0.3.12 samtools bcftools
+            python=3.11 chopper cramino mosdepth=0.3.12 samtools bcftools nanoq=0.10.0
           cache-environment: true
           cache-downloads: true
-
-      - name: Set up Rust (for nanoq)
-        uses: dtolnay/rust-toolchain@stable
 
       - name: Install dependencies
         shell: bash -l {0}
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[all]"
-
-      - name: Install nanoq via cargo
-        shell: bash -l {0}
-        run: cargo install --locked nanoq
 
       - name: Check installed CLI versions
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ Model Context Protocol server exposing lightweight QC/EDA helpers for Oxford Nan
 
 **Using conda/mamba (recommended):**
 ```bash
-mamba create -n ont-qc-mcp python=3.11 chopper cramino mosdepth samtools bcftools -c conda-forge -c bioconda
+mamba create -n ont-qc-mcp python=3.11 chopper cramino mosdepth samtools bcftools nanoq -c conda-forge -c bioconda
 conda activate ont-qc-mcp
-cargo install --locked nanoq  # nanoq via Rust toolchain
 ```
 
 **Using system package managers:**
@@ -43,7 +42,7 @@ brew install samtools bcftools
 cargo install --locked nanoq
 ```
 
-For `chopper`, `cramino`, and `mosdepth`, conda/mamba is the easiest installation method.
+For `chopper`, `cramino`, `mosdepth`, and `nanoq`, conda/mamba is the easiest installation method.
 
 ## IGV snapshot tool (optional)
 - Container runtime: Docker (preferred) or Apptainer/Singularity


### PR DESCRIPTION
## What & why

`cargo install --locked nanoq` fetches crates from crates.io during CI and
intermittently fails on transient network errors — observed on the post-merge
`main` run: `[16] Error in the HTTP2 framing layer` fetching `serde_derive`,
exit 101. It's a *pre-test* install step, so the `pytest-rerunfailures` retry
(which covers the IGV render flake) can't help here.

Fix: install `nanoq` from **bioconda** (same version, `0.10.0`), cached by
micromamba alongside `chopper` / `cramino` / `mosdepth` / `samtools` / `bcftools`.

## Why pinned `=0.10.0`, and why this is arm64-safe

`nanoq 0.10.0` is the **first bioconda release with a `linux-aarch64` build** —
every prior version is `linux-64`-only. That's almost certainly why cargo was
used originally (a source build works on any arch). Pinning `=0.10.0` guarantees
both the aarch64 binary our arm64 legs need *and* parity with the previous cargo
version.

## Net change
- `+ nanoq=0.10.0` in the micromamba `create-args`
- **removed** `Set up Rust (for nanoq)` and `Install nanoq via cargo` (−7 lines)
- the Rust toolchain is gone (it existed only to build nanoq; `cramino` is bioconda)

## Validation
- `actionlint` clean (schema + shellcheck)
- This PR's integration run exercises the bioconda nanoq path on **all four legs**
  (docker/apptainer × x86_64/arm64) — no cargo step left to flake.
- First PR through the new branch protection: must earn `CodeQL` + `lint-gate` +
  `integration-gate` green and be up-to-date before it can merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
