### PR TITLE
fix: neutralize CLI argument injection via dash-leading file paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,4 +38,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   `extra_commands`/`extra_preferences` could inject arbitrary IGV batch commands.
   All such fields are now validated and rejected fail-closed.
   Advisory: [GHSA-634p-vpv6-fxg8](https://github.com/aganezov/ont_qc_mcp/security/advisories/GHSA-634p-vpv6-fxg8).
+- Neutralize CLI argument injection via `-`-leading file paths (CWE-88): an
+  MCP-client-supplied path whose name begins with `-` (e.g. `-rf.bam` or
+  `--reference=/etc/passwd`) could be parsed by a wrapped tool as an *option*
+  instead of an input file. Every untrusted path passed to `nanoq`, `chopper`,
+  `cramino`, `samtools`, `mosdepth`, and `bcftools` is now prefixed with `./`
+  when needed, so it is always read as a file.
 

--- a/ont_qc_mcp/cli_wrappers.py
+++ b/ont_qc_mcp/cli_wrappers.py
@@ -28,6 +28,7 @@ from .utils import (
     report_progress,
     run_command,
     run_command_with_retry,
+    safe_path_arg,
 )
 
 
@@ -105,18 +106,6 @@ def build_cli_args(tool: str, flags: dict[str, Any] | None) -> list[str]:
     return args
 
 
-def _safe_path_arg(path: str | Path) -> str:
-    """Render a path as a CLI argument that can never be parsed as an option.
-
-    A path whose string form starts with ``-`` (only possible for a relative path)
-    is prefixed with ``./`` so the tool treats it as a file, not a flag; absolute
-    and ordinary relative paths are returned unchanged. This blocks argument
-    injection when an MCP-client-supplied path is passed to a CLI.
-    """
-    s = str(path)
-    return f"./{s}" if s.startswith("-") else s
-
-
 def nanoq_stats(
     path: Path,
     tools: ToolPaths,
@@ -132,7 +121,7 @@ def nanoq_stats(
     read_lengths_path: Path | None = None
     read_qualities_path: Path | None = None
 
-    cmd: list[str] = [tools.nanoq, "--stats", "--json", "--input", _safe_path_arg(path)]
+    cmd: list[str] = [tools.nanoq, "--stats", "--json", "--input", safe_path_arg(path)]
     if cfg.nanoq_aux_stats:
         with tempfile.NamedTemporaryFile(suffix=".nanoq.lengths.txt", delete=False) as tmp:
             read_lengths_path = Path(tmp.name)
@@ -209,9 +198,9 @@ def chopper_filter(
             tools.chopper,
             "filter",
             "--input",
-            _safe_path_arg(input_fastq),
+            safe_path_arg(input_fastq),
             "--output",
-            _safe_path_arg(output_fastq),
+            safe_path_arg(output_fastq),
             "--report-json",
             str(json_path),
             *flag_args,
@@ -239,7 +228,7 @@ def chopper_filter(
                 f"chopper failed (exit {exit_code}): {format_cmd(exc.result.cmd)}\n{_truncate_stderr(stderr_text)}"
             ) from exc
 
-        fallback_cmd: list[str] = [tools.chopper, "--input", _safe_path_arg(input_fastq), *flag_args]
+        fallback_cmd: list[str] = [tools.chopper, "--input", safe_path_arg(input_fastq), *flag_args]
         try:
             command_executed = fallback_cmd
             logger.warning(
@@ -302,7 +291,7 @@ def cramino_stats(
 
     flag_data, timeout = _prepare_execution("cramino", flag_data, exec_cfg)
     flag_args = build_cli_args("cramino", flag_data)
-    cmd: list[str] = [tools.cramino, *flag_args, *hist_args, _safe_path_arg(path)]
+    cmd: list[str] = [tools.cramino, *flag_args, *hist_args, safe_path_arg(path)]
     try:
         logger.debug("Executing cramino: %s", format_cmd(cmd))
         result = run_command(cmd, timeout=timeout)
@@ -346,7 +335,7 @@ def nanoq_from_bam_streaming(
     sam_cmd: list[str] = [tools.samtools, "fastq"]
     if sam_threads is not None:
         sam_cmd += ["-@", str(sam_threads)]
-    sam_cmd += [_safe_path_arg(path)]
+    sam_cmd += [safe_path_arg(path)]
 
     nano_cmd: list[str] = [tools.nanoq, "--stats", "--json"]
     read_lengths_path: Path | None = None
@@ -530,7 +519,7 @@ def mosdepth_coverage(
             tools.mosdepth,
         ]
         cmd += flag_args
-        cmd += [str(prefix), _safe_path_arg(path)]
+        cmd += [str(prefix), safe_path_arg(path)]
 
         try:
             run_command(cmd, timeout=timeout)
@@ -673,7 +662,7 @@ def run_bcftools_stats(
     """
     merged_flags, timeout = _prepare_execution("bcftools", flags, exec_cfg)
     flag_args = build_cli_args("bcftools", merged_flags)
-    cmd: list[str] = [tools.bcftools, "stats", *flag_args, _safe_path_arg(path)]
+    cmd: list[str] = [tools.bcftools, "stats", *flag_args, safe_path_arg(path)]
     report_progress(f"bcftools stats start: {path}")
     logger.debug("Executing bcftools stats: %s", format_cmd(cmd))
     try:
@@ -711,7 +700,7 @@ def run_samtools_bedcov(
     cmd: list[str] = [tools.samtools, "bedcov"]
     if sam_threads is not None:
         cmd += ["-@", str(sam_threads)]
-    cmd += [_safe_path_arg(bed_path), _safe_path_arg(bam_path)]
+    cmd += [safe_path_arg(bed_path), safe_path_arg(bam_path)]
 
     report_progress(f"samtools bedcov start: {bam_path} x {bed_path}")
     logger.debug("Executing samtools bedcov: %s", format_cmd(cmd))
@@ -758,13 +747,13 @@ def run_mosdepth_targeted(
 
     cmd: list[str] = [tools.mosdepth]
     cmd += flag_args
-    cmd += ["--by", _safe_path_arg(bed_path)]
+    cmd += ["--by", safe_path_arg(bed_path)]
 
     if thresholds:
         threshold_str = ",".join(str(t) for t in thresholds)
         cmd += ["--thresholds", threshold_str]
 
-    cmd += [str(prefix), _safe_path_arg(bam_path)]
+    cmd += [str(prefix), safe_path_arg(bam_path)]
 
     report_progress(f"mosdepth targeted start: {bam_path} x {bed_path}")
     logger.debug("Executing mosdepth targeted: %s", format_cmd(cmd))

--- a/ont_qc_mcp/cli_wrappers.py
+++ b/ont_qc_mcp/cli_wrappers.py
@@ -105,6 +105,18 @@ def build_cli_args(tool: str, flags: dict[str, Any] | None) -> list[str]:
     return args
 
 
+def _safe_path_arg(path: str | Path) -> str:
+    """Render a path as a CLI argument that can never be parsed as an option.
+
+    A path whose string form starts with ``-`` (only possible for a relative path)
+    is prefixed with ``./`` so the tool treats it as a file, not a flag; absolute
+    and ordinary relative paths are returned unchanged. This blocks argument
+    injection when an MCP-client-supplied path is passed to a CLI.
+    """
+    s = str(path)
+    return f"./{s}" if s.startswith("-") else s
+
+
 def nanoq_stats(
     path: Path,
     tools: ToolPaths,
@@ -120,7 +132,7 @@ def nanoq_stats(
     read_lengths_path: Path | None = None
     read_qualities_path: Path | None = None
 
-    cmd: list[str] = [tools.nanoq, "--stats", "--json", "--input", str(path)]
+    cmd: list[str] = [tools.nanoq, "--stats", "--json", "--input", _safe_path_arg(path)]
     if cfg.nanoq_aux_stats:
         with tempfile.NamedTemporaryFile(suffix=".nanoq.lengths.txt", delete=False) as tmp:
             read_lengths_path = Path(tmp.name)
@@ -197,7 +209,7 @@ def chopper_filter(
             tools.chopper,
             "filter",
             "--input",
-            str(input_fastq),
+            _safe_path_arg(input_fastq),
             "--output",
             str(output_fastq),
             "--report-json",
@@ -227,7 +239,7 @@ def chopper_filter(
                 f"chopper failed (exit {exit_code}): {format_cmd(exc.result.cmd)}\n{_truncate_stderr(stderr_text)}"
             ) from exc
 
-        fallback_cmd: list[str] = [tools.chopper, "--input", str(input_fastq), *flag_args]
+        fallback_cmd: list[str] = [tools.chopper, "--input", _safe_path_arg(input_fastq), *flag_args]
         try:
             command_executed = fallback_cmd
             logger.warning(
@@ -290,7 +302,7 @@ def cramino_stats(
 
     flag_data, timeout = _prepare_execution("cramino", flag_data, exec_cfg)
     flag_args = build_cli_args("cramino", flag_data)
-    cmd: list[str] = [tools.cramino, *flag_args, *hist_args, str(path)]
+    cmd: list[str] = [tools.cramino, *flag_args, *hist_args, _safe_path_arg(path)]
     try:
         logger.debug("Executing cramino: %s", format_cmd(cmd))
         result = run_command(cmd, timeout=timeout)
@@ -334,7 +346,7 @@ def nanoq_from_bam_streaming(
     sam_cmd: list[str] = [tools.samtools, "fastq"]
     if sam_threads is not None:
         sam_cmd += ["-@", str(sam_threads)]
-    sam_cmd += [str(path)]
+    sam_cmd += [_safe_path_arg(path)]
 
     nano_cmd: list[str] = [tools.nanoq, "--stats", "--json"]
     read_lengths_path: Path | None = None
@@ -518,7 +530,7 @@ def mosdepth_coverage(
             tools.mosdepth,
         ]
         cmd += flag_args
-        cmd += [str(prefix), str(path)]
+        cmd += [str(prefix), _safe_path_arg(path)]
 
         try:
             run_command(cmd, timeout=timeout)
@@ -661,7 +673,7 @@ def run_bcftools_stats(
     """
     merged_flags, timeout = _prepare_execution("bcftools", flags, exec_cfg)
     flag_args = build_cli_args("bcftools", merged_flags)
-    cmd: list[str] = [tools.bcftools, "stats", *flag_args, str(path)]
+    cmd: list[str] = [tools.bcftools, "stats", *flag_args, _safe_path_arg(path)]
     report_progress(f"bcftools stats start: {path}")
     logger.debug("Executing bcftools stats: %s", format_cmd(cmd))
     try:

--- a/ont_qc_mcp/cli_wrappers.py
+++ b/ont_qc_mcp/cli_wrappers.py
@@ -211,7 +211,7 @@ def chopper_filter(
             "--input",
             _safe_path_arg(input_fastq),
             "--output",
-            str(output_fastq),
+            _safe_path_arg(output_fastq),
             "--report-json",
             str(json_path),
             *flag_args,
@@ -711,7 +711,7 @@ def run_samtools_bedcov(
     cmd: list[str] = [tools.samtools, "bedcov"]
     if sam_threads is not None:
         cmd += ["-@", str(sam_threads)]
-    cmd += [str(bed_path), str(bam_path)]
+    cmd += [_safe_path_arg(bed_path), _safe_path_arg(bam_path)]
 
     report_progress(f"samtools bedcov start: {bam_path} x {bed_path}")
     logger.debug("Executing samtools bedcov: %s", format_cmd(cmd))
@@ -758,13 +758,13 @@ def run_mosdepth_targeted(
 
     cmd: list[str] = [tools.mosdepth]
     cmd += flag_args
-    cmd += ["--by", str(bed_path)]
+    cmd += ["--by", _safe_path_arg(bed_path)]
 
     if thresholds:
         threshold_str = ",".join(str(t) for t in thresholds)
         cmd += ["--thresholds", threshold_str]
 
-    cmd += [str(prefix), str(bam_path)]
+    cmd += [str(prefix), _safe_path_arg(bam_path)]
 
     report_progress(f"mosdepth targeted start: {bam_path} x {bed_path}")
     logger.debug("Executing mosdepth targeted: %s", format_cmd(cmd))

--- a/ont_qc_mcp/tools.py
+++ b/ont_qc_mcp/tools.py
@@ -54,7 +54,7 @@ from .schemas import (
     TargetedCoverageReport,
     VCFStats,
 )
-from .utils import CommandError, _truncate_stderr, format_cmd, report_progress, run_command
+from .utils import CommandError, _truncate_stderr, format_cmd, report_progress, run_command, safe_path_arg
 from .igv_batch import generate_igv_batch
 
 
@@ -377,7 +377,7 @@ def alignment_error_profile(
     flag_data: dict[str, Any] = dict(flags or {})
     flag_data.setdefault("threads", cfg.threads_for("samtools"))
     flag_args = build_cli_args("samtools", flag_data)
-    cmd = [tools.samtools, "stats", *flag_args, str(aln_path)]
+    cmd = [tools.samtools, "stats", *flag_args, safe_path_arg(aln_path)]
     report_progress(f"alignment_error_profile start: {aln_path}")
     try:
         logger.debug("alignment_error_profile via samtools stats: %s", format_cmd(cmd))
@@ -546,7 +546,7 @@ def _maybe_quickcheck(path: Path, tools: ToolPaths, fmt: str, exec_cfg: Executio
     if not samtools_path:
         return
 
-    cmd = [samtools_path, "quickcheck", "-v", str(path)]
+    cmd = [samtools_path, "quickcheck", "-v", safe_path_arg(path)]
     try:
         run_command(cmd, timeout=exec_cfg.timeout_for("samtools"))
     except CommandError as exc:
@@ -564,7 +564,7 @@ def _read_alignment_header_text(
     flag_data: dict[str, Any] = dict(flags or {})
     flag_data.setdefault("threads", exec_cfg.threads_for("samtools"))
     flag_args = build_cli_args("samtools", flag_data)
-    cmd = [tools.samtools, "view", "-H", *flag_args, str(path)]
+    cmd = [tools.samtools, "view", "-H", *flag_args, safe_path_arg(path)]
     try:
         result = run_command(cmd, timeout=exec_cfg.timeout_for("samtools"))
     except CommandError as exc:

--- a/ont_qc_mcp/utils.py
+++ b/ont_qc_mcp/utils.py
@@ -194,6 +194,22 @@ def format_cmd(cmd: Sequence[str]) -> str:
     return " ".join(shlex.quote(part) for part in cmd)
 
 
+def safe_path_arg(path: str | Path) -> str:
+    """Render a path as a CLI argument that can never be parsed as an option.
+
+    A path whose string form starts with ``-`` (only possible for a relative path)
+    is prefixed with ``./`` so the tool treats it as a file, not a flag; absolute
+    and ordinary relative paths are returned unchanged. This blocks argument
+    injection (CWE-88) when an MCP-client-supplied path is passed — positionally
+    or as a flag value — to any wrapped CLI. Shared by cli_wrappers and tools.
+
+    Returns ``str`` (not ``Path``) deliberately: ``Path("./-x")`` collapses back
+    to ``"-x"``, which would re-expose the leading dash.
+    """
+    s = str(path)
+    return f"./{s}" if s.startswith("-") else s
+
+
 __all__ = [
     "CommandError",
     "CommandResult",
@@ -202,5 +218,6 @@ __all__ = [
     "run_command",
     "run_command_async",
     "run_command_with_retry",
+    "safe_path_arg",
     "_truncate_stderr",
 ]

--- a/tests/test_arg_injection.py
+++ b/tests/test_arg_injection.py
@@ -1,0 +1,99 @@
+"""Regression tests for CLI argument-injection hardening.
+
+An MCP client supplies the file paths we hand to wrapped tools. A path whose
+string form starts with ``-`` (e.g. ``-rf.bam`` or ``--reference=/etc/passwd``)
+would otherwise be parsed by the tool as an *option* rather than a *file*. The
+``_safe_path_arg`` helper neutralizes this by prefixing such paths with ``./``;
+these tests pin both the helper's logic and its application at the positional
+call sites that pass an untrusted path as a bare argument.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from ont_qc_mcp.cli_wrappers import (
+    _safe_path_arg,
+    cramino_stats,
+    mosdepth_coverage,
+    run_bcftools_stats,
+)
+from ont_qc_mcp.config import ToolPaths
+
+
+# --------------------------------------------------------------------------- #
+# Helper logic
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("-evil.bam", "./-evil.bam"),  # short-option-looking name
+        ("--reference=/etc/passwd", "./--reference=/etc/passwd"),  # long option w/ value
+        ("-", "./-"),  # bare dash (stdin sentinel for many tools)
+        ("normal.bam", "normal.bam"),  # plain relative path — untouched
+        ("sub/dir/-weird.bam", "sub/dir/-weird.bam"),  # dash not leading — untouched
+        ("/abs/-weird.bam", "/abs/-weird.bam"),  # absolute — never starts with '-'
+        ("./already.bam", "./already.bam"),  # already explicit-relative — untouched
+    ],
+)
+def test_safe_path_arg_neutralizes_only_leading_dash(raw: str, expected: str) -> None:
+    result = _safe_path_arg(raw)
+    assert result == expected
+    # Must return a str, not a Path: Path("./-x") collapses back to "-x", which
+    # would re-expose the leading dash. The string form is load-bearing.
+    assert isinstance(result, str)
+
+
+def test_safe_path_arg_accepts_path_objects() -> None:
+    # str(Path(...)) preserves a leading dash, so Path inputs are handled too.
+    assert _safe_path_arg(Path("-evil.bam")) == "./-evil.bam"
+    assert _safe_path_arg(Path("/data/sample.bam")) == "/data/sample.bam"
+
+
+# --------------------------------------------------------------------------- #
+# Application at the positional call sites
+# --------------------------------------------------------------------------- #
+class _StopRun(Exception):
+    """Raised by the fake ``run_command`` to abort a wrapper immediately after
+    the command list is assembled, so the test can inspect it without executing
+    a real tool."""
+
+
+def _capture_run_command(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[str]]:
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(cmd: list[str], *args: object, **kwargs: object) -> None:
+        captured["cmd"] = list(cmd)
+        raise _StopRun
+
+    monkeypatch.setattr("ont_qc_mcp.cli_wrappers.run_command", fake_run)
+    return captured
+
+
+def test_cramino_neutralizes_dash_leading_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture_run_command(monkeypatch)
+    with pytest.raises(_StopRun):
+        cramino_stats(Path("-rf.bam"), ToolPaths(), include_hist=False)
+    cmd = captured["cmd"]
+    assert cmd[-1] == "./-rf.bam"
+    assert "-rf.bam" not in cmd  # never a bare token a tool could read as a flag
+
+
+def test_mosdepth_neutralizes_dash_leading_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture_run_command(monkeypatch)
+    with pytest.raises(_StopRun):
+        mosdepth_coverage(Path("-rf.bam"), ToolPaths())
+    cmd = captured["cmd"]
+    assert cmd[-1] == "./-rf.bam"
+    assert "-rf.bam" not in cmd
+    # The output prefix is an internal tempdir path and must stay untouched.
+    assert cmd[-2].endswith("/mosdepth")
+
+
+def test_bcftools_neutralizes_dash_leading_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture_run_command(monkeypatch)
+    with pytest.raises(_StopRun):
+        run_bcftools_stats(Path("-rf.vcf"), ToolPaths())
+    cmd = captured["cmd"]
+    assert cmd[-1] == "./-rf.vcf"
+    assert "-rf.vcf" not in cmd

--- a/tests/test_arg_injection.py
+++ b/tests/test_arg_injection.py
@@ -17,6 +17,7 @@ from ont_qc_mcp.cli_wrappers import (
     chopper_filter,
     cramino_stats,
     mosdepth_coverage,
+    nanoq_stats,
     run_bcftools_stats,
     run_mosdepth_targeted,
     run_samtools_bedcov,
@@ -45,7 +46,7 @@ from ont_qc_mcp.utils import safe_path_arg
         ("./already.bam", "./already.bam"),  # already explicit-relative — untouched
     ],
 )
-def testsafe_path_arg_neutralizes_only_leading_dash(raw: str, expected: str) -> None:
+def test_safe_path_arg_neutralizes_only_leading_dash(raw: str, expected: str) -> None:
     result = safe_path_arg(raw)
     assert result == expected
     # Must return a str, not a Path: Path("./-x") collapses back to "-x", which
@@ -53,7 +54,7 @@ def testsafe_path_arg_neutralizes_only_leading_dash(raw: str, expected: str) -> 
     assert isinstance(result, str)
 
 
-def testsafe_path_arg_accepts_path_objects() -> None:
+def test_safe_path_arg_accepts_path_objects() -> None:
     # str(Path(...)) preserves a leading dash, so Path inputs are handled too.
     assert safe_path_arg(Path("-evil.bam")) == "./-evil.bam"
     assert safe_path_arg(Path("/data/sample.bam")) == "/data/sample.bam"
@@ -149,9 +150,9 @@ def test_chopper_neutralizes_dash_leading_output_path(monkeypatch: pytest.Monkey
     with pytest.raises(_StopRun):
         chopper_filter(Path("reads.fastq"), ToolPaths(), output_fastq=Path("-evil.fastq"))
     cmd = captured["cmd"]
+    Path(cmd[cmd.index("--report-json") + 1]).unlink(missing_ok=True)  # clean json temp before asserting
     assert "./-evil.fastq" in cmd  # --output value neutralized
     assert "-evil.fastq" not in cmd
-    Path(cmd[cmd.index("--report-json") + 1]).unlink(missing_ok=True)  # clean json temp
 
 
 # --------------------------------------------------------------------------- #
@@ -189,3 +190,20 @@ def test_samtools_view_header_neutralizes_dash_leading_path(monkeypatch: pytest.
     cmd = captured["cmd"]
     assert cmd[-1] == "./-x.bam"
     assert "-x.bam" not in cmd
+
+
+def test_nanoq_stats_neutralizes_dash_leading_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    # nanoq_stats uses run_command_with_retry; the input is bound via --input <path>.
+    captured: dict[str, list[str]] = {}
+
+    def fake_retry(cmd: list[str], *args: object, **kwargs: object) -> None:
+        captured["cmd"] = list(cmd)
+        raise _StopRun
+
+    monkeypatch.setattr("ont_qc_mcp.cli_wrappers.run_command_with_retry", fake_retry)
+    with pytest.raises(_StopRun):
+        nanoq_stats(Path("-x.fastq"), ToolPaths())
+    cmd = captured["cmd"]
+    idx = cmd.index("--input")
+    assert cmd[idx + 1] == "./-x.fastq"
+    assert "-x.fastq" not in cmd

--- a/tests/test_arg_injection.py
+++ b/tests/test_arg_injection.py
@@ -8,15 +8,19 @@ these tests pin both the helper's logic and its application at the positional
 call sites that pass an untrusted path as a bare argument.
 """
 
+import shutil
 from pathlib import Path
 
 import pytest
 
 from ont_qc_mcp.cli_wrappers import (
     _safe_path_arg,
+    chopper_filter,
     cramino_stats,
     mosdepth_coverage,
     run_bcftools_stats,
+    run_mosdepth_targeted,
+    run_samtools_bedcov,
 )
 from ont_qc_mcp.config import ToolPaths
 
@@ -97,3 +101,47 @@ def test_bcftools_neutralizes_dash_leading_path(monkeypatch: pytest.MonkeyPatch)
     cmd = captured["cmd"]
     assert cmd[-1] == "./-rf.vcf"
     assert "-rf.vcf" not in cmd
+
+
+def test_samtools_bedcov_neutralizes_dash_leading_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture_run_command(monkeypatch)
+    with pytest.raises(_StopRun):
+        run_samtools_bedcov(Path("-rf.bam"), Path("-Qjunk.bed"), ToolPaths())
+    cmd = captured["cmd"]
+    # Both positional paths are client-supplied; "-Qjunk.bed" would otherwise
+    # inject samtools' -Q quality-filter flag.
+    assert "./-rf.bam" in cmd
+    assert "./-Qjunk.bed" in cmd
+    assert "-rf.bam" not in cmd
+    assert "-Qjunk.bed" not in cmd
+
+
+def test_mosdepth_targeted_neutralizes_dash_leading_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture_run_command(monkeypatch)
+    with pytest.raises(_StopRun):
+        run_mosdepth_targeted(Path("-rf.bam"), Path("-Qjunk.bed"), ToolPaths())
+    cmd = captured["cmd"]
+    assert cmd[-1] == "./-rf.bam"  # positional BAM
+    assert "./-Qjunk.bed" in cmd  # --by value (bound, neutralized for consistency)
+    assert "-rf.bam" not in cmd
+    assert "-Qjunk.bed" not in cmd
+    assert cmd[-2].endswith("/coverage")  # internal mkdtemp prefix stays untouched
+    shutil.rmtree(Path(cmd[-2]).parent, ignore_errors=True)  # clean the mkdtemp dir
+
+
+def test_chopper_neutralizes_dash_leading_output_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    # chopper's preferred path uses run_command_with_retry, and output_fastq is an
+    # MCP-tool input (exposed by app_server), so the output path needs neutralizing too.
+    captured: dict[str, list[str]] = {}
+
+    def fake_retry(cmd: list[str], *args: object, **kwargs: object) -> None:
+        captured["cmd"] = list(cmd)
+        raise _StopRun
+
+    monkeypatch.setattr("ont_qc_mcp.cli_wrappers.run_command_with_retry", fake_retry)
+    with pytest.raises(_StopRun):
+        chopper_filter(Path("reads.fastq"), ToolPaths(), output_fastq=Path("-evil.fastq"))
+    cmd = captured["cmd"]
+    assert "./-evil.fastq" in cmd  # --output value neutralized
+    assert "-evil.fastq" not in cmd
+    Path(cmd[cmd.index("--report-json") + 1]).unlink(missing_ok=True)  # clean json temp

--- a/tests/test_arg_injection.py
+++ b/tests/test_arg_injection.py
@@ -3,7 +3,7 @@
 An MCP client supplies the file paths we hand to wrapped tools. A path whose
 string form starts with ``-`` (e.g. ``-rf.bam`` or ``--reference=/etc/passwd``)
 would otherwise be parsed by the tool as an *option* rather than a *file*. The
-``_safe_path_arg`` helper neutralizes this by prefixing such paths with ``./``;
+``safe_path_arg`` helper neutralizes this by prefixing such paths with ``./``;
 these tests pin both the helper's logic and its application at the positional
 call sites that pass an untrusted path as a bare argument.
 """
@@ -14,7 +14,6 @@ from pathlib import Path
 import pytest
 
 from ont_qc_mcp.cli_wrappers import (
-    _safe_path_arg,
     chopper_filter,
     cramino_stats,
     mosdepth_coverage,
@@ -22,7 +21,13 @@ from ont_qc_mcp.cli_wrappers import (
     run_mosdepth_targeted,
     run_samtools_bedcov,
 )
-from ont_qc_mcp.config import ToolPaths
+from ont_qc_mcp.config import ExecutionConfig, ToolPaths
+from ont_qc_mcp.tools import (
+    _maybe_quickcheck,
+    _read_alignment_header_text,
+    alignment_error_profile,
+)
+from ont_qc_mcp.utils import safe_path_arg
 
 
 # --------------------------------------------------------------------------- #
@@ -40,18 +45,18 @@ from ont_qc_mcp.config import ToolPaths
         ("./already.bam", "./already.bam"),  # already explicit-relative — untouched
     ],
 )
-def test_safe_path_arg_neutralizes_only_leading_dash(raw: str, expected: str) -> None:
-    result = _safe_path_arg(raw)
+def testsafe_path_arg_neutralizes_only_leading_dash(raw: str, expected: str) -> None:
+    result = safe_path_arg(raw)
     assert result == expected
     # Must return a str, not a Path: Path("./-x") collapses back to "-x", which
     # would re-expose the leading dash. The string form is load-bearing.
     assert isinstance(result, str)
 
 
-def test_safe_path_arg_accepts_path_objects() -> None:
+def testsafe_path_arg_accepts_path_objects() -> None:
     # str(Path(...)) preserves a leading dash, so Path inputs are handled too.
-    assert _safe_path_arg(Path("-evil.bam")) == "./-evil.bam"
-    assert _safe_path_arg(Path("/data/sample.bam")) == "/data/sample.bam"
+    assert safe_path_arg(Path("-evil.bam")) == "./-evil.bam"
+    assert safe_path_arg(Path("/data/sample.bam")) == "/data/sample.bam"
 
 
 # --------------------------------------------------------------------------- #
@@ -63,14 +68,16 @@ class _StopRun(Exception):
     a real tool."""
 
 
-def _capture_run_command(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[str]]:
+def _capture_run_command(
+    monkeypatch: pytest.MonkeyPatch, target: str = "ont_qc_mcp.cli_wrappers.run_command"
+) -> dict[str, list[str]]:
     captured: dict[str, list[str]] = {}
 
     def fake_run(cmd: list[str], *args: object, **kwargs: object) -> None:
         captured["cmd"] = list(cmd)
         raise _StopRun
 
-    monkeypatch.setattr("ont_qc_mcp.cli_wrappers.run_command", fake_run)
+    monkeypatch.setattr(target, fake_run)
     return captured
 
 
@@ -145,3 +152,40 @@ def test_chopper_neutralizes_dash_leading_output_path(monkeypatch: pytest.Monkey
     assert "./-evil.fastq" in cmd  # --output value neutralized
     assert "-evil.fastq" not in cmd
     Path(cmd[cmd.index("--report-json") + 1]).unlink(missing_ok=True)  # clean json temp
+
+
+# --------------------------------------------------------------------------- #
+# tools.py builds some samtools commands directly (not via cli_wrappers), so the
+# shared guard must cover those MCP-exposed sinks too.
+# --------------------------------------------------------------------------- #
+def test_samtools_stats_neutralizes_dash_leading_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    # alignment_error_profile_tool — samtools stats <BAM>; validation resolves the
+    # path but the command receives the raw token, so the guard must apply here.
+    monkeypatch.setattr("ont_qc_mcp.tools._validate_input_file", lambda *a, **k: None)
+    captured = _capture_run_command(monkeypatch, "ont_qc_mcp.tools.run_command")
+    with pytest.raises(_StopRun):
+        alignment_error_profile("-x.bam", ToolPaths())
+    cmd = captured["cmd"]
+    assert cmd[-1] == "./-x.bam"
+    assert "-x.bam" not in cmd
+
+
+def test_samtools_quickcheck_neutralizes_dash_leading_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    # header_metadata_tool -> _maybe_quickcheck — samtools quickcheck -v <BAM>.
+    monkeypatch.setattr("ont_qc_mcp.tools.shutil.which", lambda _x: "/usr/bin/samtools")
+    captured = _capture_run_command(monkeypatch, "ont_qc_mcp.tools.run_command")
+    with pytest.raises(_StopRun):
+        _maybe_quickcheck(Path("-x.bam"), ToolPaths(), "bam", ExecutionConfig())
+    cmd = captured["cmd"]
+    assert cmd[-1] == "./-x.bam"
+    assert "-x.bam" not in cmd
+
+
+def test_samtools_view_header_neutralizes_dash_leading_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    # header_metadata_tool -> _read_alignment_header_text — samtools view -H <BAM>.
+    captured = _capture_run_command(monkeypatch, "ont_qc_mcp.tools.run_command")
+    with pytest.raises(_StopRun):
+        _read_alignment_header_text(Path("-x.bam"), ToolPaths(), None, ExecutionConfig())
+    cmd = captured["cmd"]
+    assert cmd[-1] == "./-x.bam"
+    assert "-x.bam" not in cmd


### PR DESCRIPTION
## What

Neutralizes **CLI argument injection** (CWE-88) when an untrusted, MCP-client-supplied
file path begins with `-`.

## Why

Execution is already `shell=False` with list `argv`, so there is **no shell injection**.
But the *tool's own argument parser* still treats a leading `-` as an option. A path
like `-rf.bam` or `--reference=/etc/passwd` would be parsed as a flag, not a file:

```
cramino --format json -rf.bam            # "-rf.bam" read as options
bcftools stats --reference=/etc/passwd   # attacker-chosen reference
```

## Fix

One helper, applied at every sink that passes an untrusted path to a CLI:

```python
def _safe_path_arg(path: str | Path) -> str:
    s = str(path)
    return f"./{s}" if s.startswith("-") else s
```

A dash-leading string is necessarily a *relative* path, so `./` makes it an explicit
file the parser can't read as an option. Applied to: `nanoq`, `chopper` (×2),
`cramino`, `samtools`, `mosdepth`, `bcftools`.

Three deliberate boundaries:

- **Returns `str`, not `Path`** — `str(Path("./-x"))` collapses back to `"-x"`, which
  would re-expose the dash. The string form is the security property (asserted in tests).
- **Only a *leading*-dash string is touched** — `sub/dir/-x.bam` and `/abs/-x.bam` are
  already safe; rewriting them would be noise.
- **The mosdepth `prefix` is *not* wrapped** — it is an internal `TemporaryDirectory`
  path, never client-controlled (a test pins `cmd[-2]` ending in `/mosdepth`).

## Testing

`tests/test_arg_injection.py` (11 tests):

- Parametrized unit coverage of `_safe_path_arg` (leading short/long option, bare `-`,
  absolute, nested-dash, plain relative, return-type).
- Wrapper-level regression for the positional sites (`cramino`, `mosdepth`, `bcftools`):
  a mocked `run_command` captures the assembled `argv` and asserts the path appears only
  as `./-…`, never as a bare `-…` token.

`ruff` / `ruff format --check` / `mypy ont_qc_mcp tests` all clean.

## Notes

Moderate hardening with a safe representation, so a normal `fix:` (no security advisory,
unlike the C1 IGV control-character fix). Recorded under `Security` in `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
