### PR TITLE
fix: bind sequencing_summary columns by exact name first

### DIFF
--- a/ont_qc_mcp/parsers.py
+++ b/ont_qc_mcp/parsers.py
@@ -638,6 +638,27 @@ def summarize_header(metadata: HeaderMetadata) -> str:
     return summary
 
 
+def _find_column(
+    column_map: dict[str, int],
+    exact_names: tuple[str, ...],
+    substrings: tuple[str, ...],
+) -> int | None:
+    """Resolve a column index by exact (lowercased) name first, then by substring.
+
+    Exact canonical names take priority; the substring fallback applies only when no
+    exact name is present, and the first matching column in header order wins. This
+    avoids loose-match mis-binding — e.g. a decoy ``*time*`` column hijacking
+    ``start_time`` (#17).
+    """
+    for name in exact_names:
+        if name in column_map:
+            return column_map[name]
+    for col_name, idx in column_map.items():
+        if any(s in col_name for s in substrings):
+            return idx
+    return None
+
+
 def parse_sequencing_summary(file_path: Path) -> SequencingSummaryStats:
     """
     Parse ONT sequencing summary file (tab-separated).
@@ -667,21 +688,12 @@ def parse_sequencing_summary(file_path: Path) -> SequencingSummaryStats:
     columns = header_line.split("\t")
     column_map = {col.lower(): idx for idx, col in enumerate(columns)}
 
-    # Find required columns (with flexible naming)
-    length_col_idx = None
-    qscore_col_idx = None
-    start_time_col_idx = None
-    channel_col_idx = None
-
-    for col_name, idx in column_map.items():
-        if "length" in col_name or "sequence_length" in col_name:
-            length_col_idx = idx
-        if "qscore" in col_name or "quality" in col_name:
-            qscore_col_idx = idx
-        if "start_time" in col_name or "time" in col_name:
-            start_time_col_idx = idx
-        if "channel" in col_name:
-            channel_col_idx = idx
+    # Find required columns: exact canonical name first, then a substring fallback,
+    # first match wins — so a decoy "*time*" column can't hijack start_time (#17).
+    length_col_idx = _find_column(column_map, ("sequence_length_template",), ("sequence_length", "length"))
+    qscore_col_idx = _find_column(column_map, ("mean_qscore_template",), ("qscore", "quality"))
+    start_time_col_idx = _find_column(column_map, ("start_time",), ("start_time",))
+    channel_col_idx = _find_column(column_map, ("channel",), ("channel",))
 
     if length_col_idx is None:
         raise ValueError(f"Required column 'sequence_length_template' not found in {file_path}")

--- a/ont_qc_mcp/parsers.py
+++ b/ont_qc_mcp/parsers.py
@@ -688,8 +688,10 @@ def parse_sequencing_summary(file_path: Path) -> SequencingSummaryStats:
     columns = header_line.split("\t")
     column_map = {col.lower(): idx for idx, col in enumerate(columns)}
 
-    # Find required columns: exact canonical name first, then a substring fallback,
-    # first match wins — so a decoy "*time*" column can't hijack start_time (#17).
+    # Resolve each column by exact canonical name first (dict lookup), then a
+    # "contains" fallback for vendor name variants (e.g. start_time_utc); first
+    # match wins. Dropping the loose bare-"time" match is the #17 fix — a decoy
+    # *time* column can no longer hijack start_time.
     length_col_idx = _find_column(column_map, ("sequence_length_template",), ("sequence_length", "length"))
     qscore_col_idx = _find_column(column_map, ("mean_qscore_template",), ("qscore", "quality"))
     start_time_col_idx = _find_column(column_map, ("start_time",), ("start_time",))

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -12,6 +12,7 @@ from ont_qc_mcp.parsers import (
     parse_error_profile,
     parse_mosdepth_summary,
     parse_nanoq_json,
+    parse_sequencing_summary,
     parse_vcf_header,
     summarize_header,
 )
@@ -363,3 +364,24 @@ def test_nanoq_cache_thread_safe(monkeypatch, tmp_path):
 
     assert call_count["n"] == 1
     m_tools._NANOQ_CACHE.clear()
+
+
+def test_sequencing_summary_binds_exact_start_time_not_decoy(tmp_path: Path) -> None:
+    # Regression for #17: a decoy "*time*" column AFTER start_time. The loose
+    # substring matcher (last-match-wins) binds start_time to template_duration_time,
+    # corrupting run_duration_hours / yield_per_hour.
+    content = (
+        "read_id\tchannel\tstart_time\tsequence_length_template\tmean_qscore_template\ttemplate_duration_time\n"
+        "read1\t1\t0.0\t1000\t12.0\t100.0\n"
+        "read2\t2\t1.0\t2000\t11.0\t100.0\n"
+        "read3\t3\t2.0\t1500\t13.0\t100.0\n"
+    )
+    summary = tmp_path / "sequencing_summary.txt"
+    summary.write_text(content)
+
+    stats = parse_sequencing_summary(summary)
+
+    # start_time spans 0..2 (duration 2.0); the decoy column is constant 100.0.
+    # Binding to the decoy collapses duration to 0.0 and empties the windows.
+    assert stats.run_duration_hours == 2.0
+    assert len(stats.yield_per_hour) > 0

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -385,3 +385,23 @@ def test_sequencing_summary_binds_exact_start_time_not_decoy(tmp_path: Path) -> 
     # Binding to the decoy collapses duration to 0.0 and empties the windows.
     assert stats.run_duration_hours == 2.0
     assert len(stats.yield_per_hour) > 0
+
+
+def test_sequencing_summary_binds_exact_length_qscore_not_decoy(tmp_path: Path) -> None:
+    # length/qscore share the start_time failure mode (#17): a decoy column that
+    # also matches the substring and appears later would win under last-match-wins.
+    content = (
+        "read_id\tsequence_length_template\tmean_qscore_template\tmeasurement_length\tread_quality\n"
+        "read1\t1000\t12.0\t1\t99.0\n"
+        "read2\t2000\t11.0\t1\t99.0\n"
+        "read3\t1500\t13.0\t1\t99.0\n"
+    )
+    summary = tmp_path / "sequencing_summary.txt"
+    summary.write_text(content)
+
+    stats = parse_sequencing_summary(summary)
+
+    # Exact names win over the decoys: total_yield from sequence_length_template
+    # (4500, not 3) and mean_qscore from mean_qscore_template (12.0, not 99.0).
+    assert stats.total_yield == 4500
+    assert stats.mean_qscore == 12.0


### PR DESCRIPTION
Closes #17.

## What

`parse_sequencing_summary` bound header columns by loose substring match with
**last-match-wins** semantics, so a decoy `*time*` column after `start_time`
(e.g. `template_duration_time`) hijacked the `start_time` binding — silently
corrupting `run_duration_hours` and `yield_per_hour`. Length / qscore / channel
share the failure mode under non-standard headers.

## Fix

A `_find_column(exact_names, substrings)` helper: **exact canonical name first**,
substring fallback only when no exact match, **first match wins**. The bare
`"time"` substring is dropped so a decoy column can never hijack `start_time`.
Applied to length / qscore / start_time / channel.

## Test

`tests/test_parsers.py::test_sequencing_summary_binds_exact_start_time_not_decoy` —
an inline TSV with a decoy `template_duration_time` column. **Fails before** the fix
(`run_duration_hours == 0.0`, empty `yield_per_hour`), **passes after**. Full unit
suite: 108 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
