### PR TITLE
chore: add bug-report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,6 +33,11 @@ code snippet too as a fallback.
 
 <!-- Concrete inputs/steps, or a minimal fixture, that trigger it. -->
 
+## Environment
+
+<!-- OPTIONAL — OS, Python version, and relevant CLI tool versions (nanoq, chopper,
+cramino, samtools, mosdepth, bcftools) when the bug may depend on them. -->
+
 ## Proposed direction
 
 <!-- OPTIONAL — include only if the fix is genuinely clear; omit rather than guess. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Report a correctness or security defect
+---
+
+<!--
+Shape: Summary → Location → Root cause → Impact → Reproduction → Proposed direction.
+Keep it tight; delete any section that doesn't apply.
+-->
+
+## Summary
+
+<!-- One or two sentences: what's wrong and the user-visible impact. -->
+
+## Location
+
+<!--
+Use a DURABLE GitHub permalink, not a bare file:line — line numbers go stale.
+Open the file on the default branch, press `y` to pin the URL to the commit SHA,
+select the line(s), and paste; GitHub renders the snippet inline. Add a minimal
+code snippet too as a fallback.
+-->
+
+## Root cause
+
+<!-- Why it happens. -->
+
+## Impact
+
+<!-- What breaks, and whether it fails silently (the worst kind). -->
+
+## Reproduction
+
+<!-- Concrete inputs/steps, or a minimal fixture, that trigger it. -->
+
+## Proposed direction
+
+<!-- OPTIONAL — include only if the fix is genuinely clear; omit rather than guess. -->


### PR DESCRIPTION
Closes #20.

## What

Adds `.github/ISSUE_TEMPLATE/bug_report.md` — the bug-issue shape we standardized,
checked in so the web "New Issue" UI and `gh`-created issues stay consistent.

## Shape

Summary → Location → Root cause → Impact → Reproduction → *optional* Proposed direction.
Location carries a **durable-permalink** reminder (bare line numbers go stale — #19
originally cited numbers already wrong for `main`).

## Notes

- Markdown to start; a YAML issue *form* (structured fields) is a later upgrade if we want it.
- Heavier automation (stale-bots, auto-assign, project boards, labelers) intentionally
  skipped for a solo repo.
- CI: this touches only `.github/`, so the code/integration jobs skip via change-detection
  (aggregator gates still pass); CodeQL + review run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
