### PR TITLE
fix: convert sequencing_summary start_time from seconds to hours

### DIFF
--- a/ont_qc_mcp/parsers.py
+++ b/ont_qc_mcp/parsers.py
@@ -762,16 +762,20 @@ def parse_sequencing_summary(file_path: Path) -> SequencingSummaryStats:
                 n50 = length
                 break
 
+    # start_time is recorded in SECONDS since run start; convert to hours so
+    # run_duration_hours and the 1-hour windows are actually in hours (#19).
+    start_times_hours = [t / 3600.0 for t in start_times]
+
     # Calculate run duration
     run_duration_hours = None
-    if start_times:
-        run_duration_hours = max(start_times) - min(start_times)
+    if start_times_hours:
+        run_duration_hours = max(start_times_hours) - min(start_times_hours)
 
     # Calculate yield per hour windows (1-hour bins)
     yield_per_hour: list[RunYieldWindow] = []
-    if start_times and lengths:
-        min_time = min(start_times)
-        max_time = max(start_times)
+    if start_times_hours and lengths:
+        min_time = min(start_times_hours)
+        max_time = max(start_times_hours)
         if max_time > min_time:
             # Create 1-hour windows
             window_size = 1.0  # hours
@@ -784,7 +788,7 @@ def parse_sequencing_summary(file_path: Path) -> SequencingSummaryStats:
                 window_yield = 0
                 window_reads = 0
 
-                for i, start_time in enumerate(start_times):
+                for i, start_time in enumerate(start_times_hours):
                     if window_start <= start_time < window_end:
                         window_yield += lengths[i]
                         window_reads += 1

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -381,9 +381,10 @@ def test_sequencing_summary_binds_exact_start_time_not_decoy(tmp_path: Path) -> 
 
     stats = parse_sequencing_summary(summary)
 
-    # start_time spans 0..2 (duration 2.0); the decoy column is constant 100.0.
-    # Binding to the decoy collapses duration to 0.0 and empties the windows.
-    assert stats.run_duration_hours == 2.0
+    # The decoy column is constant, so binding to it collapses run_duration to 0
+    # and empties the windows; binding to the real (varying) start_time gives a
+    # positive duration. Units-agnostic on purpose — the seconds→hours fix is #19.
+    assert stats.run_duration_hours is not None and stats.run_duration_hours > 0
     assert len(stats.yield_per_hour) > 0
 
 
@@ -405,3 +406,22 @@ def test_sequencing_summary_binds_exact_length_qscore_not_decoy(tmp_path: Path) 
     # (4500, not 3) and mean_qscore from mean_qscore_template (12.0, not 99.0).
     assert stats.total_yield == 4500
     assert stats.mean_qscore == 12.0
+
+
+def test_sequencing_summary_run_duration_in_hours_not_seconds(tmp_path: Path) -> None:
+    # ONT start_time is in SECONDS since run start; run_duration_hours and the
+    # yield_per_hour window starts must be in hours, not raw seconds (#19).
+    content = (
+        "read_id\tstart_time\tsequence_length_template\n"
+        "r1\t0.0\t1000\n"
+        "r2\t7200.0\t1000\n"  # 7200 s = 2 h
+    )
+    summary = tmp_path / "sequencing_summary.txt"
+    summary.write_text(content)
+
+    stats = parse_sequencing_summary(summary)
+
+    assert stats.run_duration_hours == 2.0  # not 7200.0
+    # windows are 1 hour wide: r1 in hour 0, r2 in hour 2 (start in hours, not seconds)
+    starts = sorted(w.window_start_hours for w in stats.yield_per_hour)
+    assert starts == [0.0, 2.0]  # not [0.0, 7200.0]


### PR DESCRIPTION
Closes #19.

## What

ONT `sequencing_summary` stores `start_time` in **seconds** since run start, but
`parse_sequencing_summary` used the raw values, so `run_duration_hours` reported
*seconds* (a 2-hour run → `7200.0`) and the "1-hour" `yield_per_hour` windows were
really 1-second windows (thousands of them). Silent — no error raised.

## Fix

Convert `start_times` to hours once (`/3600`); `run_duration_hours` and the window
math then operate in hours, with `window_size = 1.0` finally meaning one hour.

## Tests

- **New** `test_sequencing_summary_run_duration_in_hours_not_seconds` — a 7200 s span
  must read as `2.0` h with window starts in hours (`[0.0, 2.0]`, not `[0.0, 7200.0]`).
  Fails before (`7200.0 == 2.0`), passes after.
- **Adapted** the #18 column-binding test to a units-agnostic assertion (non-zero
  duration). It asserted `run_duration_hours == 2.0` on second-valued data, which the
  units fix necessarily changes; its real purpose — correct column binding — is preserved.

110 unit tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
