### PR TITLE
fix: pair length and start_time per read in sequencing_summary

### DIFF
--- a/ont_qc_mcp/parsers.py
+++ b/ont_qc_mcp/parsers.py
@@ -700,10 +700,11 @@ def parse_sequencing_summary(file_path: Path) -> SequencingSummaryStats:
     if length_col_idx is None:
         raise ValueError(f"Required column 'sequence_length_template' not found in {file_path}")
 
-    # Parse data rows
-    lengths: list[int] = []
+    # Parse data rows. Collect (length, start_time) as one record per row so the two
+    # stay aligned: a row whose start_time fails to parse must not shift lengths onto
+    # another read's window (#23). qscore (mean) and channel (set) are aggregates.
+    reads: list[tuple[int, float | None]] = []
     qscores: list[float] = []
-    start_times: list[float] = []
     channels: set[int] = set()
 
     for line_num, line in enumerate(lines[1:], start=2):
@@ -717,30 +718,30 @@ def parse_sequencing_summary(file_path: Path) -> SequencingSummaryStats:
 
         try:
             length = int(parts[length_col_idx])
-            lengths.append(length)
-
-            if qscore_col_idx is not None and len(parts) > qscore_col_idx:
-                try:
-                    qscore = float(parts[qscore_col_idx])
-                    qscores.append(qscore)
-                except (ValueError, IndexError):
-                    pass
-
-            if start_time_col_idx is not None and len(parts) > start_time_col_idx:
-                try:
-                    start_time = float(parts[start_time_col_idx])
-                    start_times.append(start_time)
-                except (ValueError, IndexError):
-                    pass
-
-            if channel_col_idx is not None and len(parts) > channel_col_idx:
-                try:
-                    channel = int(parts[channel_col_idx])
-                    channels.add(channel)
-                except (ValueError, IndexError):
-                    pass
         except (ValueError, IndexError):
             continue
+
+        start_time: float | None = None
+        if start_time_col_idx is not None and len(parts) > start_time_col_idx:
+            try:
+                start_time = float(parts[start_time_col_idx])
+            except (ValueError, IndexError):
+                start_time = None
+        reads.append((length, start_time))
+
+        if qscore_col_idx is not None and len(parts) > qscore_col_idx:
+            try:
+                qscores.append(float(parts[qscore_col_idx]))
+            except (ValueError, IndexError):
+                pass
+
+        if channel_col_idx is not None and len(parts) > channel_col_idx:
+            try:
+                channels.add(int(parts[channel_col_idx]))
+            except (ValueError, IndexError):
+                pass
+
+    lengths = [length for length, _ in reads]
 
     total_reads = len(lengths)
     total_yield = sum(lengths)
@@ -762,20 +763,22 @@ def parse_sequencing_summary(file_path: Path) -> SequencingSummaryStats:
                 n50 = length
                 break
 
-    # start_time is recorded in SECONDS since run start; convert to hours so
-    # run_duration_hours and the 1-hour windows are actually in hours (#19).
-    start_times_hours = [t / 3600.0 for t in start_times]
+    # Reads with a parsed start_time, paired (length, start_time_hours). start_time is
+    # recorded in SECONDS since run start; convert to hours (#19).
+    timed = [(length, st / 3600.0) for length, st in reads if st is not None]
 
     # Calculate run duration
     run_duration_hours = None
-    if start_times_hours:
-        run_duration_hours = max(start_times_hours) - min(start_times_hours)
+    if timed:
+        times = [t for _, t in timed]
+        run_duration_hours = max(times) - min(times)
 
     # Calculate yield per hour windows (1-hour bins)
     yield_per_hour: list[RunYieldWindow] = []
-    if start_times_hours and lengths:
-        min_time = min(start_times_hours)
-        max_time = max(start_times_hours)
+    if timed:
+        times = [t for _, t in timed]
+        min_time = min(times)
+        max_time = max(times)
         if max_time > min_time:
             # Create 1-hour windows
             window_size = 1.0  # hours
@@ -788,9 +791,9 @@ def parse_sequencing_summary(file_path: Path) -> SequencingSummaryStats:
                 window_yield = 0
                 window_reads = 0
 
-                for i, start_time in enumerate(start_times_hours):
+                for length, start_time in timed:
                     if window_start <= start_time < window_end:
-                        window_yield += lengths[i]
+                        window_yield += length
                         window_reads += 1
 
                 if window_reads > 0:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -425,3 +425,24 @@ def test_sequencing_summary_run_duration_in_hours_not_seconds(tmp_path: Path) ->
     # windows are 1 hour wide: r1 in hour 0, r2 in hour 2 (start in hours, not seconds)
     starts = sorted(w.window_start_hours for w in stats.yield_per_hour)
     assert starts == [0.0, 2.0]  # not [0.0, 7200.0]
+
+
+def test_sequencing_summary_no_desync_on_partial_row_parse(tmp_path: Path) -> None:
+    # r1's start_time is unparseable, so it drops out of the timed reads. length must
+    # stay paired with start_time so each yield window carries the RIGHT read's length,
+    # not one shifted onto a neighbor (#23).
+    content = (
+        "read_id\tstart_time\tsequence_length_template\n"
+        "r1\tbad\t9999\n"  # length parses, start_time does not
+        "r2\t0.0\t1000\n"  # hour 0
+        "r3\t7200.0\t2000\n"  # hour 2
+    )
+    summary = tmp_path / "sequencing_summary.txt"
+    summary.write_text(content)
+
+    stats = parse_sequencing_summary(summary)
+
+    windows = {w.window_start_hours: w.yield_bp for w in stats.yield_per_hour}
+    # r2 at hour 0 → its own length 1000; r3 at hour 2 → its own 2000.
+    # The desync bug would attribute 9999 (r1) and 1000 (r2) instead.
+    assert windows == {0.0: 1000, 2.0: 2000}


### PR DESCRIPTION
Closes #23.

## What

`parse_sequencing_summary` collected `lengths` and `start_times` as separate parallel
lists — `lengths` always appended, `start_times` inside a `try/except`. A row with a
valid length but an **unparseable start_time** grew one list and not the other, so
`lengths[i]` and `start_times[i]` desynced and the yield-per-hour windows attributed the
**wrong read's length** (silent).

## Fix

Collect one `(length, start_time | None)` record per row, so an index always refers to the
same read. `lengths` is derived from it; the windowing pairs length + start_time directly.
`qscore` (mean) and `channel` (set) are aggregates and stay as-is.

## Test

`test_sequencing_summary_no_desync_on_partial_row_parse` — a row whose start_time is `bad`
no longer shifts lengths: windows are `{0h: 1000, 2h: 2000}` (each read's own length), not
`{0h: 9999, 2h: 1000}`. Fails before, passes after. 111 unit tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
