### PR TITLE
chore: attribution trailers on commits only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,9 @@ sequencing data (FASTQ / BAM / CRAM / VCF / BED).
 - **Branches & commits:** never commit to `main`. Use a feature branch and small
   [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`,
   `chore:`, `docs:`, `ci:`).
+- **Attribution:** only **commit messages** carry the `Co-Authored-By: Claude …`
+  trailer. PR bodies, issues, and comments carry **no** trailer or footer — no
+  `Co-Authored-By`, no "🤖 Generated with Claude Code".
 - **Verify before commit:** run `scripts/ci-local.sh` (reproduces the CI lint tier
   via uv + the lockfile; `--floors` mirrors the min-deps job), or quickly:
   `uv run ruff check . && uv run mypy ont_qc_mcp tests && uv run pytest`.


### PR DESCRIPTION
Closes #25.

## What

Adds an **Attribution** bullet to `AGENTS.md` → *Working conventions*: only commit
messages carry the `Co-Authored-By` trailer; PR bodies, issues, and comments carry
none. In practice this drops the `🤖 Generated with Claude Code` footer from PR bodies
(issues/comments were already clean).

## Note

This PR body itself follows the new policy — no footer.
